### PR TITLE
Feature map project assets ignore null bbox

### DIFF
--- a/salesforce/my-conservation-life/force-app/main/default/lwc/map/map.js
+++ b/salesforce/my-conservation-life/force-app/main/default/lwc/map/map.js
@@ -32,6 +32,7 @@ export default class Map extends LightningElement {
     initializeLeaflet() {
         const mapRoot = this.template.querySelector('.map-root');
         this.map = L.map(mapRoot);
+        this.map.fitWorld();
     }
 
     /**

--- a/salesforce/my-conservation-life/force-app/main/default/lwc/mapProjectAssets/__tests__/mapProjectAssets.test.js
+++ b/salesforce/my-conservation-life/force-app/main/default/lwc/mapProjectAssets/__tests__/mapProjectAssets.test.js
@@ -53,7 +53,8 @@ describe('c-map-project-assets', () => {
             latLng: jest.fn(),
             map: jest.fn(() => ({
                 type: 'map',
-                fitBounds: fitBounds
+                fitBounds: fitBounds,
+                fitWorld: jest.fn()
             })),
             marker: jest.fn(),
             tileLayer: jest.fn(() => ({

--- a/salesforce/my-conservation-life/force-app/main/default/lwc/mapProjectAssets/__tests__/mapProjectAssets.test.js
+++ b/salesforce/my-conservation-life/force-app/main/default/lwc/mapProjectAssets/__tests__/mapProjectAssets.test.js
@@ -8,14 +8,19 @@ const LWC_STARTUP_WAIT = 10; // milliseconds to wait the LWC to finish loading
 describe('c-map-project-assets', () => {
     let element;
     let featureGroupAddTo;
+    let fitBounds;
     const CONSOLE_ERROR = global.console.error;
+
+    let ASSETS;
+    let BBOX;
 
     /**
      * Load the LWC with the given attribute values.
      * 
      * This returns a promise that waits until the LWC has likely finished starting.
      * 
-     * @param {*} projectId 
+     * @param {*} [projectId] Project ID
+     * @returns {Promise<any>} Promise that resolves when loading should be complete
      */
     const load = (projectId) => {
         element.projectId = projectId;
@@ -36,15 +41,21 @@ describe('c-map-project-assets', () => {
     });
 
     beforeEach(() => {
-        assets.find = jest.fn(() => Promise.resolve([]));
-        bboxAssets.get = jest.fn(() => Promise.resolve({}));
+        ASSETS = [{ latitude: 1, longitude: 2 }];
+        BBOX = { latitude_min: 1, latitude_max: 1, longitude_min: 2, longitude_max: 2 };
+
+        assets.find = jest.fn(() => Promise.resolve(ASSETS));
+        bboxAssets.get = jest.fn(() => Promise.resolve(BBOX));
         featureGroupAddTo = jest.fn();
+        fitBounds = jest.fn();
 
         global.L = {
+            latLng: jest.fn(),
             map: jest.fn(() => ({
                 type: 'map',
-                fitBounds: jest.fn()
+                fitBounds: fitBounds
             })),
+            marker: jest.fn(),
             tileLayer: jest.fn(() => ({
                 addTo: jest.fn()
             })),
@@ -71,15 +82,25 @@ describe('c-map-project-assets', () => {
 
     it('adds assets to the map when a projectId is specified', () =>
         load(2).then(() => {
-            expect(global.L.featureGroup).toHaveBeenCalledWith([]);
+            expect(global.L.featureGroup).toHaveBeenCalled();
+            expect(global.L.featureGroup.mock.calls[0][0]).toHaveLength(1);
             expect(featureGroupAddTo).toHaveBeenCalled();
         })
     );
 
     it('adds assets to the map when no projectId is specified', () =>
         load(undefined).then(() => {
-            expect(global.L.featureGroup).toHaveBeenCalledWith([]);
+            expect(global.L.featureGroup).toHaveBeenCalled();
+            expect(global.L.featureGroup.mock.calls[0][0]).toHaveLength(1);
             expect(featureGroupAddTo).toHaveBeenCalled();
         })
     );
+
+    it('does not call fitBounds when there are no assets and there is no bounding box', async () => {
+        ASSETS = [];
+        BBOX = { latitude_min: null, latitude_max: null, longitude_min: null, longitude_max: null };
+        await load(undefined).then(() => {
+            expect(fitBounds).not.toHaveBeenCalled();
+        });
+    });
 });

--- a/salesforce/my-conservation-life/force-app/main/default/lwc/mapProjectAssets/mapProjectAssets.js
+++ b/salesforce/my-conservation-life/force-app/main/default/lwc/mapProjectAssets/mapProjectAssets.js
@@ -39,9 +39,12 @@ export default class MapProjectAssets extends LightningElement {
         const map = event.detail;
 
         this.assetsBboxPromise.then((bbox) => {
-            map.fitBounds([
-                [bbox.latitude_min, bbox.longitude_min],
-                [bbox.latitude_max, bbox.longitude_max]]);
+            const isNull = Object.values(bbox).some(coord => coord === null || coord === undefined);
+            if (!isNull) {
+                map.fitBounds([
+                    [bbox.latitude_min, bbox.longitude_min],
+                    [bbox.latitude_max, bbox.longitude_max]]);
+            }
         });
 
         this.assetsPromise.then((assetArray) => {


### PR DESCRIPTION
When there are no assets, bbox-assets returns null coordinates. This fixes a bug where Leaflet would throw an exception as we tried to fitBounds with null coordinates. We solve this in this case by not calling fitBounds. When we do not call fitBounds, we instead set as a default behavior in the Map LWC to fit the entire world in view.

Resolves the bug described in https://trello.com/c/exYcU60H